### PR TITLE
aws-psql: db_name property not updatable

### DIFF
--- a/reference/aws-postgres.html.md.erb
+++ b/reference/aws-postgres.html.md.erb
@@ -120,7 +120,7 @@ provision only:
       <td>String</td>
       <td>Name for the database to create</td>
       <td><code>vsbdb</code></td>
-      <td>provision and update</td>
+      <td>provision</td>
     </tr>
     <tr>
       <td><code>region</code></td>


### PR DESCRIPTION
Hi Docs 👋 

Small amend, the db_name property is no longer updatable. Only needs to be on main branch

Thanks!

[#183069983](https://www.pivotaltracker.com/story/show/183069983)

