### PR TITLE
Fix `engine_version` documentation discrepancies

### DIFF
--- a/reference/aws-aurora-postgresql.html.md.erb
+++ b/reference/aws-aurora-postgresql.html.md.erb
@@ -76,7 +76,7 @@ provision only:
         The Aurora PostgreSQL engine version, such as <code>14.4</code>. Some versions do not support some features.
         For more information, see the <a href="https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.20180305.html">AWS documentation</a>.
       </td>
-      <td><code>null</code> which results in the AWS default</td>
+      <td>None</td>
       <td>provision and update</td>
     </tr>
     <tr>
@@ -143,17 +143,6 @@ provision only:
         Aurora Serverless v2 uses.
       </td>
       <td><code>null</code></td>
-      <td>provision and update</td>
-    </tr>
-    <tr>
-      <td><code>engine_version</code></td>
-      <td>String</td>
-      <td>
-        This parameter is required.
-        The Aurora PostgreSQL engine version, such as <code>14.4</code>. Some versions do not support some features.
-        For more information, see the <a href="https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.20180305.html">AWS documentation</a>.
-      </td>
-      <td><code>null</code> which results in the AWS default</td>
       <td>provision and update</td>
     </tr>
     <tr>


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
1.4