### PR TITLE
docs: redis - restore cache_size equivalents table

### DIFF
--- a/reference/aws-redis.html.md.erb
+++ b/reference/aws-redis.html.md.erb
@@ -275,3 +275,28 @@ Add the following block to keep the `large-ha` plan:
   "redis_version": "6.0"
 }
 ```
+
+## <a id="cache-size-node-type"></a> Equivalence of cache_size and node_type
+
+The previously pre-configured plans for Amazon ElastiCache for Redis and the cache_size and node_type equivalences:
+
+| Plan      | Cache Size | Description | AWS Cache Node Type | HA  |
+|-----------|-----|--------------------|---------------------|-----|
+| small     | 1   | minimum 1&nbsp;GB  | cache.t2.small      | no  |
+| medium    | 4   | minimum 4&nbsp;GB  | cache.m5.large      | no  |
+| large     | 16  | minimum 16&nbsp;GB | cache.r4.xlarge     | no  |
+| small-ha  | 1   | minimum 1&nbsp;GB  | cache.t2.small      | yes |
+| medium-ha | 4   | minimum 4&nbsp;GB  | cache.m5.large      | yes |
+| large-ha  | 16  | minimum 16&nbsp;GB | cache.r4.xlarge     | yes |
+
+
+Table of equivalents for cache_size and node_type not used by any of the previously pre-configured plans:
+
+| Cache Size | AWS Cache Node Type |
+|------------|---------------------|
+| 2          | cache.t3.medium     |
+| 8          | cache.m5.xlarge     |
+| 32         | cache.r4.2xlarge    |
+| 64         | cache.r4.4xlarge    |
+| 128        | cache.r4.8xlarge    |
+| 256        | cache.r5.12xlarge   |


### PR DESCRIPTION
[#184405164](https://www.pivotaltracker.com/story/show/184405164)

Which other branches should this be merged with (if any)?
none
