### PR TITLE
postgres: v15 not supported

### DIFF
--- a/reference/aws-aurora-postgresql.html.md.erb
+++ b/reference/aws-aurora-postgresql.html.md.erb
@@ -74,6 +74,7 @@ provision only:
       <td>
         This parameter is required.
         The Aurora PostgreSQL engine version, such as <code>14.4</code>. Some versions do not support some features.
+        PostgreSQL 15 is not supported.
         For more information, see the <a href="https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.20180305.html">AWS documentation</a>.
       </td>
       <td>None</td>

--- a/reference/aws-postgres.html.md.erb
+++ b/reference/aws-postgres.html.md.erb
@@ -33,7 +33,7 @@ The following table lists parameters which can only be configured for additional
 | `free`             | When false, service instances of this service plan have a cost.                                                          | true    | No       |
 | `bindable`         | Specifies whether service instances of the service plan can bind to applications.                                        | true    | No       |
 | `plan_updateable`  | Whether the plan supports upgrading, downgrading, or sidegrading to another version.                                     | true    | No       |
-| `postgres_version` | The version for the PostgreSQL instance. Can be any supported major or minor version.                                    | _n/a_   | Yes      |
+| `postgres_version` | The version for the PostgreSQL instance. Can be any supported major or minor version. PostgreSQL 15 is not supported.    | _n/a_   | Yes      |
 | `storage_gb`       | This is storage volume size for service instance, which is 5&ndash;4096&nbsp;GB.                                         | _n/a_   | Yes      |
 | `cores`            | Deprecated - Minimum number of cores for the service instance. 2&ndash;64, multiples of 2. Use `instance_class` instead. | _n/a_   | No       |
 | `metadata.displayName`    | Name to use when displaying the plan in the Marketplace.                                     | _n/a_   | No       |


### PR DESCRIPTION
[#183641081](https://www.pivotaltracker.com/story/show/183641081)

Which other branches should this be merged with (if any)?
- 1.4
- 1.3

For future reference, technically this also applies to 1.2, but that's going out of support in a few weeks and the documentation is structured differently, so I don't think it's worth back-porting to 1.2
