### PR TITLE
consistency of default values

### DIFF
--- a/reference/aws-aurora-mysql.html.md.erb
+++ b/reference/aws-aurora-mysql.html.md.erb
@@ -70,7 +70,7 @@ provision only:
       <td><code>instance_name</code></td>
       <td>String</td>
       <td>The name of the AWS instance to create.</td>
-      <td><code>csb-auroramy-INSTANCE-ID</code></td>
+      <td><code>csb-auroramysql-INSTANCE-ID</code></td>
       <td>provision</td>
     </tr>
     <tr>
@@ -416,7 +416,7 @@ provision only:
           When setting this value, <code>storage_encrypted</code> must be enabled.
           When not set, the AWS-managed key is used for encrypting the database.
         </td>
-        <td><code>null</code></td>
+        <td><code>""</code></td>
         <td>provision</td>
     </tr>
     <tr>
@@ -455,7 +455,7 @@ provision only:
         An outage occurs if you change the backup retention period from <code>0</code> to
         a nonzero value or the reverse.
       </td>
-      <td><code>7</code></td>
+      <td><code>1</code></td>
       <td>provision and update</td>
     </tr>
   </tbody>

--- a/reference/aws-aurora-postgresql.html.md.erb
+++ b/reference/aws-aurora-postgresql.html.md.erb
@@ -387,7 +387,7 @@ provision only:
           When setting this value, <code>storage_encrypted</code> must be enabled.
           When not set, the AWS-managed key is used for encrypting the database.
         </td>
-        <td><code>null</code></td>
+        <td><code>""</code></td>
         <td>provision</td>
     </tr>
     <tr>
@@ -426,7 +426,7 @@ provision only:
         occurs if you change the backup retention period from <code>0</code> to
         a nonzero value or the reverse.
       </td>
-      <td><code>7</code></td>
+      <td><code>1</code></td>
       <td>provision and update</td>
     </tr>
     <tr>

--- a/reference/aws-dynamodb.html.md.erb
+++ b/reference/aws-dynamodb.html.md.erb
@@ -112,42 +112,42 @@ provision only:
       <td><code>table_name</code></td>
       <td>String</td>
       <td>(Required) The name of the table</td>
-      <td><em>n/a</em></td>
+      <td>None</td>
       <td>provision and update</td>
     </tr>
     <tr>
       <td><code>hash_key</code></td>
       <td>String</td>
       <td>(Required) The key to use as the hash key</td>
-      <td><em>n/a</em></td>
+      <td>None</td>
       <td>provision and update</td>
     </tr>
     <tr>
       <td><code>range_key</code></td>
       <td>String</td>
       <td>(Required) The key to use as the range key</td>
-      <td><em>n/a</em></td>
+      <td>None</td>
       <td>provision and update</td>
     </tr>
     <tr>
       <td><code>attributes</code></td>
       <td>Array</td>
       <td>(Required) A list of attributes and their types, for example: <code>[{"name":"id", "type":"S"}, {"name":"value", "type":"S"}]</code></td>
-      <td><em>n/a</em></td>
+      <td>None</td>
       <td>provision and update</td>
     </tr>
     <tr>
       <td><code>global_secondary_indexes</code></td>
       <td>Array</td>
       <td>(Required) A list of global secondary indexes, for example: <code>[{"name":"KeyIndex", "hash_key":"key", "range_key":"value", "projection_type":"INCLUDE", "non_key_attributes":["id"]}]</code></td>
-      <td><em>n/a</em></td>
+      <td>None</td>
       <td>provision and update</td>
     </tr>
     <tr>
       <td><code>local_secondary_indexes</code></td>
       <td>Array</td>
       <td>A list of local secondary indexes, for example: <code>[{"name":"KeyIndex", "hash_key":"key", "range_key":"value", "projection_type":"INCLUDE", "non_key_attributes":["id"]}]</code></td>
-      <td><em>n/a</em></td>
+      <td><code>[]</code></td>
       <td>provision and update</td>
     </tr>
     <tr>
@@ -214,14 +214,14 @@ provision only:
       <td><code>write_capacity</code></td>
       <td>Number</td>
       <td>The number of write units for this table. If <code>billing_mode</code> is <code>PROVISIONED</code>, this field should be greater than 0.</td>
-      <td><em>n/a</em></td>
+      <td><code>0</code></td>
       <td>provision and update</td>
     </tr>
     <tr>
       <td><code>read_capacity</code></td>
       <td>Number</td>
       <td>The number of read units for this table. If <code>billing_mode</code> is <code>PROVISIONED</code>, this field should be greater than 0.</td>
-      <td><em>n/a</em></td>
+      <td><code>0</code></td>
       <td>provision and update</td>
     </tr>
     <tr>

--- a/reference/aws-mysql.html.md.erb
+++ b/reference/aws-mysql.html.md.erb
@@ -331,7 +331,7 @@ provision only:
       <td><code>parameter_group_name</code></td>
       <td>String</td>
       <td>The MySQL parameter group name for the service instance.</td>
-      <td><code>default.mysql.MYSQL-VERSION</code></td>
+      <td><code>""</code></td>
       <td>provision and update</td>
     </tr>
     <tr>
@@ -352,7 +352,7 @@ provision only:
       <td><code>option_group_name</code></td>
       <td>String</td>
       <td>Name of the database option group to associate with.</td>
-      <td><code>None</code></td>
+      <td><code>""</code></td>
       <td>provision and update</td>
     </tr>
     <tr>

--- a/reference/aws-redis.html.md.erb
+++ b/reference/aws-redis.html.md.erb
@@ -85,7 +85,7 @@ provision only:
       <td><code>instance_name</code></td>
       <td>String</td>
       <td>The name of the AWS instance to create</td>
-      <td><code>csb-redis-INSTANCE-ID</code></td>
+      <td><code>csbINSTANCE-ID</code></td>
       <td>provision</td>
     </tr>
     <tr>
@@ -140,7 +140,7 @@ provision only:
         If you try to perform the operation, the Cloud Service Broker incurs an error because of
         the mechanism established to prevent the destruction of the instance.
       </td>
-      <td><code>None</code></td>
+      <td>None</td>
       <td>provision and update</td>
     </tr>
     <tr>


### PR DESCRIPTION
- if enclosed in &lt;code&gt;, the value should exactly match the brokerpak spec
- when no default exists, `None` should be used rather than N/A
- where the default is badly formatted (csbINSTANCE-ID for instance) the docs should show the value that matches the brokerpak spec, rather than what we thing the brokerpak spec should have been

[#184710879](https://www.pivotaltracker.com/story/show/184710879)

Which other branches should this be merged with (if any)?
- 1.4
- 1.3
