### PR TITLE
feat: improve stack selection logic

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -37,6 +37,9 @@ New features and changes in this release:
   The broker automatically creates AWS tags for the service instance GUID and the org-space GUID. You
   can now also configure default global tags to add for each AWS service.
 
+- **Improve stack selection to try with "cflinuxfs3" before using the default value:**
+  Previously, it was possible in some scenarios that the default value was a Windows stack causing
+  tile installation to fail.
 
 ### Amazon ElastiCache for Redis
 


### PR DESCRIPTION
[#185675276]

When there are multiple build packs installed and non of them is a cflinuxfs4 , when creating the droplet for the tile with the default stack, CF will just take the first matching one.

But if both Windows and Linux have installed the binary_buildpack, it can happen that it matches a Windows buildpack. The implemented solution is to also check for cflinuxfs3 in the get_stack() function

Which other branches should this be merged with (if any)?
