### PR TITLE
doc: known issue selecting stack during install

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -224,8 +224,7 @@ This release has the following issues:
 
 - **Failure to select the right stack during install:**
 
-  When there are multiple build packs installed and non of them is a cflinuxfs4, it can happen that 
-  it matches a Windows buildpack if both Windows and Linux have installed the binary_buildpack.
+Incorrect buildpack stack association when the stack `cflinuxfs4` is not available in your deployment.
 
 #### Amazon ElastiCache for Redis
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -220,6 +220,13 @@ This release has the following fixes:
 
 This release has the following issues:
 
+#### General
+
+- **Failure to select the right stack during install:**
+
+  When there are multiple build packs installed and non of them is a cflinuxfs4, it can happen that 
+  it matches a Windows buildpack if both Windows and Linux have installed the binary_buildpack.
+
 #### Amazon ElastiCache for Redis
 
 - **Inconsistent design in the format accepted in the `redis_version` property:**


### PR DESCRIPTION
[#185675276]

When there are multiple build packs installed and non of them is a cflinuxfs4 , when creating the droplet for the tile with the default stack, CF will just take the first matching one.

But if both Windows and Linux have installed the binary_buildpack, it can happen that it matches a Windows buildpack.

Which other branches should this be merged with (if any)? none