### PR TITLE
fix: [MSSQL] eliminate the default and go for nullable

### DIFF
--- a/reference/aws-mssql.html.md.erb
+++ b/reference/aws-mssql.html.md.erb
@@ -139,10 +139,10 @@ provision only:
       <td>Integer</td>
       <td>
         Upper limit in gibibytes to which Amazon RDS can automatically scale the storage of the DB instance.
-        Must be greater than or equal to <code>storage_gb</code> or <code>0</code> to disable storage autoscaling.
+        Must be greater than or equal to <code>storage_gb</code>. Set it to <code>null</code> or <code>0</code> to disable storage autoscaling.
         For more information check <a href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.StorageTypes.html#USER_PIOPS.Autoscaling">Managing capacity automatically with Amazon RDS storage autoscaling</a>.
       </td>
-      <td>0</td>
+      <td>None</td>
       <td>provision and update</td>
     </tr>
     <tr>


### PR DESCRIPTION
[#185149499](https://www.pivotaltracker.com/story/show/185149499)

- We made the field nullable yet the default is 0 and docs say we need to set to 0 to disable. This means it doesn't need to be nullable.
- In previous discussions around this kind of interface, the team agreed that a 0 value, although in use by the provider and probably by the API, it is not as intuitive as null, hence preferred way to implement would be to set to null by default and instruct the user to set to null to disable, whilst treating null as 0 when passing it to terraform.

Code implementation: https://github.com/cloudfoundry/csb-brokerpak-aws/pull/1087

Which other branches should this be merged with (if any)? Noneee