### PR TITLE
docs: remove unsupported statement for PG 15

### DIFF
--- a/reference/aws-aurora-postgresql.html.md.erb
+++ b/reference/aws-aurora-postgresql.html.md.erb
@@ -76,7 +76,6 @@ provision only:
       <td>
         This parameter is required.
         The Aurora PostgreSQL engine version, such as <code>14.4</code>. Some versions do not support some features.
-        PostgreSQL 15 is not supported.
         For more information, see the <a href="https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.20180305.html">AWS Documentation</a>.
       </td>
       <td>None</td>

--- a/reference/aws-postgres.html.md.erb
+++ b/reference/aws-postgres.html.md.erb
@@ -25,7 +25,7 @@ The following table lists parameters which can only be configured for additional
 | `free`                    | When false, service instances of this service plan have a cost.                                                          | true    | No       |
 | `bindable`                | Specifies whether service instances of the service plan can bind to applications.                                        | true    | No       |
 | `plan_updateable`         | Whether the plan supports upgrading, downgrading, or sidegrading to another version.                                     | true    | No       |
-| `postgres_version`        | The version for the PostgreSQL instance. Can be any supported major or minor version. PostgreSQL 15 is not supported.    | _n/a_   | Yes      |
+| `postgres_version`        | The version for the PostgreSQL instance. Can be any supported major or minor version.                                    | _n/a_   | Yes      |
 | `storage_gb`              | This is storage volume size for service instance. The minimum size is 5&nbsp;GB.                                         | _n/a_   | Yes      |
 | `cores`                   | Deprecated - Minimum number of cores for the service instance. 2&ndash;64, multiples of 2. Use `instance_class` instead. | _n/a_   | No       |
 | `metadata.displayName`    | Name to use when displaying the plan in the Marketplace.                                                                 | _n/a_   | No       |


### PR DESCRIPTION
While testing PostgreSQL 16, we noticed that we had not removed a statement saying that PostgreSQL 15 was no longer supported. This is incorrect as the work to support it was done some time ago.

[#187078888](https://www.pivotaltracker.com/story/show/187078888)

Which other branches should this be merged with (if any)?
- main
- 1.8
- 1.7
